### PR TITLE
countdown and error handling for iframe added

### DIFF
--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -2,7 +2,7 @@ import styles from "./ResultScreen.module.css";
 import MotionSection from "./MotionSection";
 import { composeStickerFromSource } from "../utils/composeSticker";
 import { composeStickerWithHtmlLabel } from "../utils/htmlToCanvas";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { FC } from "react";
 import type { GenerationResult } from "../types";
 
@@ -33,6 +33,10 @@ const ResultScreen: FC<Props> = ({
   );
   const [stickerVisible, setStickerVisible] = useState(false);
   const [servicesTriggered, setServicesTriggered] = useState(false);
+
+  const [countdown, setCountdown] = useState<number>(30);
+  const [isCountdownActive, setIsCountdownActive] = useState(false);
+  const countdownInterval = useRef<NodeJS.Timeout | null>(null);
 
   const composeSticker = async (source?: string): Promise<string> => {
     const src = source || stickerSource;
@@ -137,6 +141,9 @@ const ResultScreen: FC<Props> = ({
   }, [displayedSrc, onShare]);
 
   const printSticker = async () => {
+    if (isCountdownActive) {
+      setCountdown(30);
+    }
     let outSrc = stickerSource;
     try {
       outSrc = await composeSticker();
@@ -155,29 +162,61 @@ const ResultScreen: FC<Props> = ({
     document.body.appendChild(printFrame);
 
     const doc = printFrame.contentWindow?.document;
-    if (doc) {
-      doc.open();
-      doc.write(`<html><head><title>${
-        resultAgent?.name || "Agent"
-      } Sticker</title><style>
-        html,body{height:100%;margin:0}
-        .print-body{height:100%;display:flex;align-items:center;justify-content:center;background:#fff}
-        .print-image{max-width:90vw;max-height:90vh;object-fit:contain;}
-      </style></head><body class="print-body">
-        <img src="${outSrc}" class="print-image"/>
-      </body></html>`);
-      doc.close();
-      printFrame.contentWindow?.focus();
-      printFrame.contentWindow?.print();
+    if (!printFrame.contentWindow || !doc) {
+      if (document.body.contains(printFrame)) {
+        document.body.removeChild(printFrame);
+      }
+      onPrint();
+      setIsCountdownActive(true);
+      setCountdown(30);
+      return;
     }
+
+    doc.open();
+    doc.write(`<html><head><title>${
+      resultAgent?.name || "Agent"
+    } Sticker</title><style>
+      html,body{height:100%;margin:0}
+      .print-body{height:100%;display:flex;align-items:center;justify-content:center;background:#fff}
+      .print-image{max-width:90vw;max-height:90vh;object-fit:contain;}
+    </style></head><body class="print-body">
+      <img src="${outSrc}" class="print-image"/>
+    </body></html>`);
+    doc.close();
+    printFrame.contentWindow.focus();
+    printFrame.contentWindow.print();
 
     setTimeout(() => {
       if (document.body.contains(printFrame)) {
         document.body.removeChild(printFrame);
       }
       onPrint();
+      setIsCountdownActive(true);
+      setCountdown(30);
     }, 1000);
   };
+
+  useEffect(() => {
+    if (!isCountdownActive) {
+      if (countdownInterval.current) clearInterval(countdownInterval.current);
+      return;
+    }
+    setCountdown(30);
+    countdownInterval.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          if (countdownInterval.current)
+            clearInterval(countdownInterval.current);
+          if (onRestart) onRestart();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => {
+      if (countdownInterval.current) clearInterval(countdownInterval.current);
+    };
+  }, [isCountdownActive, onRestart]);
 
   const getPersonalityData = () => {
     if (!resultAgent) return null;
@@ -310,6 +349,17 @@ const ResultScreen: FC<Props> = ({
                 alt="Result sticker"
                 className={styles.resultImage}
               />
+            </div>
+            <div
+              style={{
+                visibility: isCountdownActive ? "visible" : "hidden",
+                margin: "16px 0",
+                color: "#0ecc7e",
+                fontWeight: 600,
+                fontSize: 20,
+              }}
+            >
+              <p>Redirecting to start in {countdown} seconds...</p>
             </div>
             <div className={styles.ctaSection}>
               <button className={styles.printButton} onClick={printSticker}>


### PR DESCRIPTION
This pull request adds an automatic countdown and redirect feature to the `ResultScreen` component after printing a sticker. When a user prints, a 30-second countdown is started, displaying a message and automatically triggering a restart when the countdown finishes. The implementation uses React state and intervals to manage the countdown and ensures proper cleanup of timers and DOM elements.

**Countdown and Redirect Functionality:**

* Introduced `countdown`, `isCountdownActive`, and `countdownInterval` state/refs to manage a 30-second countdown after printing. The countdown is reset if the user prints again before it finishes. [[1]](diffhunk://#diff-1016e2eab0b9a625efb943f38a646ecbdaeafedf4ca1a11bb71d73b398caa2b3R37-R40) [[2]](diffhunk://#diff-1016e2eab0b9a625efb943f38a646ecbdaeafedf4ca1a11bb71d73b398caa2b3R144-R146)
* Added a `useEffect` hook to start and manage the countdown interval, automatically calling `onRestart` when the countdown reaches zero and cleaning up intervals as needed.

**User Experience Enhancements:**

* Displayed a visible message "Redirecting to start in X seconds..." during the countdown, styled for prominence.

**Print Flow Robustness:**

* Improved error handling in the print logic to ensure the print frame is always removed from the DOM, and the countdown is started even if the print window cannot be opened.
* Refactored the print logic for clarity and reliability, including resetting the countdown if a print is triggered during an active countdown. [[1]](diffhunk://#diff-1016e2eab0b9a625efb943f38a646ecbdaeafedf4ca1a11bb71d73b398caa2b3R144-R146) [[2]](diffhunk://#diff-1016e2eab0b9a625efb943f38a646ecbdaeafedf4ca1a11bb71d73b398caa2b3L158-R174)

**Imports and Typings:**

* Added `useRef` import to support the countdown interval logic.