### PR TITLE
Distance between selfie and buttons added

### DIFF
--- a/src/components/PhotoCapture.module.css
+++ b/src/components/PhotoCapture.module.css
@@ -60,6 +60,7 @@
   align-items: center;
   justify-content: center;
   margin: 20px 0;
+  margin-bottom: 60px;
 }
 
 .cameraFrame {


### PR DESCRIPTION
This pull request makes a minor styling adjustment to the `PhotoCapture.module.css` file, increasing the bottom margin for improved layout spacing. 

- Increased the bottom margin of the `.photoCaptureContainer` class to `60px` to enhance visual spacing.