### PR TITLE
Minor bugfixes

### DIFF
--- a/src/components/QuestionScreen.module.css
+++ b/src/components/QuestionScreen.module.css
@@ -125,7 +125,7 @@
   box-shadow: 0 10px 20px 0 rgba(6, 6, 6, 0.1);
   /* use a pale, non-transparent background to ensure clear selected state */
   background: linear-gradient(180deg, #e8fff4 0%, #dff8fb 100%);
-  border: 2px solid rgba(0, 0, 0, 0.9); /* explicit black border */
+  border: 2px solid #0ECC7E; /* explicit black border */
 }
 
 .optionIcon {
@@ -303,7 +303,6 @@
   .questionTitle {
     font-size: 28px;
     line-height: 32px;
-    padding: 0 20px;
   }
 
   .questionOptions {

--- a/src/components/QuestionScreen.module.css
+++ b/src/components/QuestionScreen.module.css
@@ -303,6 +303,7 @@
   .questionTitle {
     font-size: 28px;
     line-height: 32px;
+    padding: 0 20px;
   }
 
   .questionOptions {

--- a/src/components/RadioListQuestion.module.css
+++ b/src/components/RadioListQuestion.module.css
@@ -41,7 +41,7 @@
     rgba(14, 204, 126, 0.08),
     rgba(83, 192, 210, 0.06)
   );
-  border: 2px solid rgba(0, 0, 0, 0.9); /* explicit black border for selected */
+  border: 2px solid #0ecc7e;
 }
 
 .radioButton {

--- a/src/components/RadioListQuestion.module.css
+++ b/src/components/RadioListQuestion.module.css
@@ -117,11 +117,11 @@
 @media (max-width: 480px) {
   .radioListContainer {
     gap: 10px;
+    max-width: 340px;
   }
 
   .radioOption {
     width: 100%;
-    max-width: 280px;
     padding: 12px 24px;
     gap: 16px;
   }


### PR DESCRIPTION
This pull request updates the visual styling of selected options in the question and radio list components to use a consistent green border color, and improves the mobile layout for radio list questions. The main changes include updating border colors and adjusting the maximum width for better responsiveness on small screens.

**Visual Consistency Updates:**

* Changed the selected option border color in `QuestionScreen.module.css` from an opaque black to a green (`#0ECC7E`) for better visual consistency.
* Updated the selected radio option border color in `RadioListQuestion.module.css` to use the same green (`#0ecc7e`) instead of black.

**Mobile Responsiveness Improvements:**

* Added a `max-width` of 340px to `.radioListContainer` for screens smaller than 480px, improving layout on mobile devices.